### PR TITLE
Add shell completions for bash, zsh, and fish

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -26,4 +26,9 @@ prepare() {
 package() {
     # Install binary
     install -Dm755 "$srcdir/cloudfleet" "$pkgdir/usr/bin/cloudfleet"
+
+    # Install shell completions
+    "$srcdir/cloudfleet" completion bash | install -Dm644 /dev/stdin "$pkgdir/usr/share/bash-completion/completions/cloudfleet"
+    "$srcdir/cloudfleet" completion zsh | install -Dm644 /dev/stdin "$pkgdir/usr/share/zsh/site-functions/_cloudfleet"
+    "$srcdir/cloudfleet" completion fish | install -Dm644 /dev/stdin "$pkgdir/usr/share/fish/vendor_completions.d/cloudfleet.fish"
 }


### PR DESCRIPTION
## Summary
- Generate and install shell completion scripts during package install using the built-in `cloudfleet completion` command
- Adds completions for **bash**, **zsh**, and **fish** to the standard system paths
- Follows the same pattern used by other CLI packages (helm, kubectl, docker)

## Files installed
- `usr/share/bash-completion/completions/cloudfleet`
- `usr/share/zsh/site-functions/_cloudfleet`
- `usr/share/fish/vendor_completions.d/cloudfleet.fish`

## Test plan
- [x] Built package locally with `makepkg -sf`
- [x] Verified completion files are present in the package archive
- [x] Installed package with `pacman -U` and confirmed it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)